### PR TITLE
Add Proofpoint's report on TA406

### DIFF
--- a/2021/2021.11.18.TA406_North_Korea_aligned/IOCs/indicators.csv
+++ b/2021/2021.11.18.TA406_North_Korea_aligned/IOCs/indicators.csv
@@ -1,0 +1,154 @@
+IoC,Type
+acount-pro[.]club,Domain
+acount-pro[.]live,Domain
+anlysis-info[.]xyz,Domain
+asia-studies[.]net,Domain
+bignaver[.]com,Domain
+carnegieinsider[.]com,Domain
+change-pw[.]com,Domain
+clonesec[.]us,Domain
+cloudnaver[.]com,Domain
+cloudocument[.]com,Domain
+cloudsecurityservice[.]net,Domain
+dailycloudservice[.]com,Domain
+daumhelp[.]net,Domain
+daum-protect[.]com,Domain
+deioncube[.]biz,Domain
+delivernaver[.]com,Domain
+delivers-security[.]com,Domain
+delivers-security[.]net,Domain
+diplomatictraining[.]com,Domain
+document-package[.]online,Domain
+documentpackages[.]link,Domain
+documentpackages[.]online,Domain
+documentpackage[.]space,Domain
+documentpackages[.]space,Domain
+documentpackages[.]store,Domain
+documentserver[.]site,Domain
+down-error[.]com,Domain
+download-apks[.]com,Domain
+downloader-hanmail[.]net,Domain
+download-live[.]com,Domain
+emailnaver[.]com,Domain
+globalcloudservices[.]org,Domain
+gooapi[.]online,Domain
+google-acount[.]com,Domain
+goolg-e[.]com,Domain
+goolge[.]space,Domain
+govermentweb[.]site,Domain
+help-master[.]online,Domain
+helpnaver[.]host,Domain
+helpnaver[.]link,Domain
+helpnaver[.]online,Domain
+help-naver[.]site,Domain
+helpnaver[.]site,Domain
+help-secure[.]info,Domain
+hpronto-login[.]com,Domain
+itamaraty[.]net,Domain
+knowledgeofworld[.]org,Domain
+lnfo-master[.]com,Domain
+login-protect[.]club,Domain
+login-protect[.]online,Domain
+mail-master[.]online,Domain
+mail[.]summitz[.]com,Domain
+microsoft-pro[.]host,Domain
+microsoft-pro[.]live,Domain
+microsoft-pro[.]site,Domain
+microsoft-pro[.]space,Domain
+midsecurity[.]org,Domain
+mid-service[.]com,Domain
+mid-service[.]org,Domain
+myethrvvallet[.]com,Domain
+mysoftazure[.]com,Domain
+naverhelp[.]com,Domain
+naversecurity[.]us,Domain
+nicnaver[.]com,Domain
+nidnaver[.]host,Domain
+nidnaver[.]press,Domain
+nidnaver[.]site,Domain
+nidnaver[.]store,Domain
+noreply-cc[.]online,Domain
+noreply-goolge[.]com,Domain
+noreply-sec[.]online,Domain
+noreply-yahoo[.]com,Domain
+oaass-torrent[.]com,Domain
+proattachfile[.]com,Domain
+pronto-login[.]info,Domain
+pw-change[.]com,Domain
+resetpolicy[.]com,Domain
+resetprofile[.]com,Domain
+rfa[.]news,Domain
+rnaii[.]com,Domain
+rnail-inbox[.]com,Domain
+rnailm[.]com,Domain
+rnail-suport[.]site,Domain
+rneail[.]com,Domain
+secureaction[.]ru,Domain
+securelevel[.]site,Domain
+security-acount[.]info,Domain
+securitycounci1report[.]org,Domain
+security-delivers[.]com,Domain
+securityforcastreport[.]com,Domain
+security-lnfo[.]com,Domain
+security-nid[.]space,Domain
+security-pro[.]me,Domain
+security-pro[.]online,Domain
+securitysettings[.]info,Domain
+seoulhobi[.]biz,Domain
+servicenaver[.]com,Domain
+servicenidnaver[.]com,Domain
+sinoforecast[.]com,Domain
+softfilemanage[.]com,Domain
+ssidnaver[.]com,Domain
+stategov[.]biz,Domain
+support-info[.]network,Domain
+unosa[.]org,Domain
+voakorea[.]news,Domain
+voakoreas[.]com,Domain
+voipgoogle[.]com,Domain
+vpsino[.]org,Domain
+webofknowledg[.]com,Domain
+xfindphoneloc[.]com,Domain
+xn--mcrosoft-online-hic[.]com,Domain
+0member-services[.]hol[.]es,Domain
+attachdown[.]000webhostapp[.]com,Domain
+attachdownload[.]000webhostapp[.]com,Domain
+attachdownload[.]99on[.]com,Domain
+dnsservice[.]esy[.]es,Domain
+emailru[.]99on[.]com,Domain
+firefox-plug[.]c1[.]biz,Domain
+koryogroup[.]1apps[.]com,Domain
+lookyes[.]c1[.]biz,Domain
+north-korea[.]medianewsonline[.]com,Domain
+online-manual[.]c1[.]biz,Domain
+romanovawillkillyou[.]c1[.]biz,Domain
+securitydownload[.]99on[.]com,Domain
+silverlog[.]hol[.]es,Domain
+softlay-ware[.]c1[.]biz,Domain
+takemetoyouheart[.]c1[.]biz,Domain
+taketodjnfnei898[.]c1[.]biz,Domain
+taketodjnfnei898[.]ueuo[.]com,Domain
+upsrv[.]16mb[.]com,Domain
+vscode-plug[.]c1[.]biz,Domain
+win10-ms[.]c1[.]biz,Domain
+1006ieudneu[.]atwebpages[.]com,Domain
+1995ieudneu[.]atwebpages[.]com,Domain
+fd-com[.]fr,Compromised Infrastructure
+influencer[.]jvproduccionessv[.]com,Compromised Infrastructure
+mail[.]apm[.]co[.]kr,Compromised Infrastructure
+oaass[.]co[.]kr,Compromised Infrastructure
+rabadaun[.]com,Compromised Infrastructure
+simple[.]kswebdesign[.]eu,Compromised Infrastructure
+www[.]acl-medias[.]fr,Compromised Infrastructure
+u13448720[.]ct[.]sendgrid[.]net,SendGrid Hostnames
+u19402039[.]ct[.]sendgrid[.]net,SendGrid Hostnames
+u7747409[.]ct[.]sendgrid[.]net,SendGrid Hostnames
+u8253848[.]ct[.]sendgrid[.]net,SendGrid Hostnames
+u9810308[.]ct[.]sendgrid[.]net,SendGrid Hostnames
+222.118.183[.]131,Email Sending Infrastructure (March 2021)
+192.109.119[.]6,Email Sending Infrastructure (April 2021)
+108.177.235[.]226,Email Sending Infrastructure (May 2021)
+108.62.12[.]11,Email Sending Infrastructure (May 2021)
+212.114.52[.]227,Email Sending Infrastructure (July 2021)
+de1d1931f2e821209f1508e4b7306e7eef296a42f21fe9784e22cf4670acd296,YoreKey
+347fdbd435f044fb1209125b22aaac5a9d826cfe5e5d543b190dc904cdd371c3,YoreKey


### PR DESCRIPTION
Proposing to add the new report on the attribution of TA406 which was published by Proofpoint yesterday.